### PR TITLE
Enable C# 12

### DIFF
--- a/src/DendroDocs.Tool/Analyzers/SourceAnalyzer.cs
+++ b/src/DendroDocs.Tool/Analyzers/SourceAnalyzer.cs
@@ -266,11 +266,6 @@ public class SourceAnalyzer(SemanticModel semanticModel, List<TypeDescription> t
 
     private void ExtractAttributes(SyntaxList<AttributeListSyntax> attributes, List<IAttributeDescription> attributeDescriptions)
     {
-        if (attributes == null)
-        {
-            return;
-        }
-
         foreach (var attribute in attributes.SelectMany(a => a.Attributes))
         {
             var attributeDescription = new AttributeDescription(semanticModel.GetTypeDisplayString(attribute), attribute.Name.ToString());

--- a/src/DendroDocs.Tool/DendroDocs.Tool.csproj
+++ b/src/DendroDocs.Tool/DendroDocs.Tool.csproj
@@ -42,6 +42,8 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="DendroDocs.Shared" Version="0.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />


### PR DESCRIPTION
# Pull Request Template

## Description

Enable C# 12 support by upgrading `Microsoft.CodeAnalysis.CSharp.Workspaces` and `Microsoft.CodeAnalysis.VisualBasic.Workspaces` dependencies to `4.11.0` instead of `4.4.0` referenced by Buildalyzer.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Ran analyzer against .NET 8.0/C# 12 application using collection initializers

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

