### PR TITLE
Always check for `nameof` invocations first

### DIFF
--- a/src/DendroDocs.Tool/Analyzers/InvocationsAnalyzer.cs
+++ b/src/DendroDocs.Tool/Analyzers/InvocationsAnalyzer.cs
@@ -52,16 +52,16 @@ internal class InvocationsAnalyzer(SemanticModel semanticModel, List<Statement> 
     {
         var expression = this.GetExpressionWithSymbol(node);
 
-        if (Program.RuntimeOptions.VerboseOutput && semanticModel.GetSymbolInfo(expression).Symbol == null)
+        if (semanticModel.GetConstantValue(node).HasValue && IsNameofExpression(node.Expression))
         {
-            Console.WriteLine("WARN: Could not resolve type of invocation of the following block:");
-            Console.WriteLine(node.ToFullString());
+            // nameof is compiler sugar, and is actually a method we are not interrested in
             return;
         }
 
-        if (semanticModel.GetConstantValue(node).HasValue && string.Equals((node.Expression as IdentifierNameSyntax)?.Identifier.ValueText, "nameof", StringComparison.Ordinal))
+        if (Program.RuntimeOptions.VerboseOutput && semanticModel.GetSymbolInfo(expression).Symbol is null)
         {
-            // nameof is compiler sugar, and is actually a method we are not interrested in
+            Console.WriteLine("WARN: Could not resolve type of invocation of the following block:");
+            Console.WriteLine(node.ToFullString());
             return;
         }
 
@@ -142,5 +142,10 @@ internal class InvocationsAnalyzer(SemanticModel semanticModel, List<Statement> 
         statements.Add(assignmentDescription);
 
         base.VisitAssignmentExpression(node);
+    }
+
+    private static bool IsNameofExpression(ExpressionSyntax expression)
+    {
+        return expression is IdentifierNameSyntax identifier && string.Equals(identifier.Identifier.ValueText, "nameof", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR addresses an issue where `nameof` invocations were generating invalid warnings during verbose output.

The change ensures that `nameof` is recognized as compiler-generated sugar first, preventing unnecessary warnings when analyzing invocations.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Manual testing with verbose output to ensure no warnings are generated for `nameof` invocations.
- [X] Ran existing unit tests to verify that other functionality remains intact.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
