### PR TITLE
Detect positional attribute argument name via constructor

### DIFF
--- a/tests/DendroDocs.Tool.Tests/AttributeDeclarationTests.cs
+++ b/tests/DendroDocs.Tool.Tests/AttributeDeclarationTests.cs
@@ -40,6 +40,54 @@ public class AttributeDeclarationTests
         types[0].Attributes.Should().HaveCount(1);
         types[0].Attributes[0].Should().NotBeNull();
         types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+        types[0].Attributes[0].Arguments.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ClassWithAttribute_Should_HaveAttributeWithPositionalArgumentInCollection()
+    {
+        // Assign
+        var source =
+            """
+            [System.Obsolete("Message")]
+            class Test
+            {
+            }
+            """;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes[0].Arguments.Should().HaveCount(1);
+        types[0].Attributes[0].Arguments[0].Should().NotBeNull();
+        types[0].Attributes[0].Arguments[0].Name.Should().Be("message");
+        types[0].Attributes[0].Arguments[0].Value.Should().Be("Message");
+    }
+
+    [TestMethod]
+    public void ClassWithAttribute_Should_HaveAttributeWithMultiplePositionalArgumentsInCollection()
+    {
+        // Assign
+        var source =
+            """
+            [System.Obsolete("Message", true)]
+            class Test
+            {
+            }
+            """;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes[0].Arguments.Should().HaveCount(2);
+        types[0].Attributes[0].Arguments[0].Name.Should().Be("message");
+        types[0].Attributes[0].Arguments[0].Type.Should().Be("string");
+        types[0].Attributes[0].Arguments[0].Value.Should().Be("Message");
+        types[0].Attributes[0].Arguments[1].Name.Should().Be("error");
+        types[0].Attributes[0].Arguments[1].Type.Should().Be("bool");
+        types[0].Attributes[0].Arguments[1].Value.Should().Be("true");
     }
 
     [TestMethod]
@@ -63,7 +111,30 @@ public class AttributeDeclarationTests
         types[0].Attributes[0].Arguments[0].Name.Should().Be("DiagnosticId");
         types[0].Attributes[0].Arguments[0].Value.Should().Be("ID");
     }
-    
+
+    [TestMethod]
+    public void ClassWithAttribute_Should_HaveAttributeWithMixedArgumentInCollection()
+    {
+        // Assign
+        var source =
+            """
+            [System.Obsolete("Message", DiagnosticId = "ID")]
+            class Test
+            {
+            }
+            """;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes[0].Arguments.Should().HaveCount(2);
+        types[0].Attributes[0].Arguments[0].Name.Should().Be("message");
+        types[0].Attributes[0].Arguments[0].Value.Should().Be("Message");
+        types[0].Attributes[0].Arguments[1].Name.Should().Be("DiagnosticId");
+        types[0].Attributes[0].Arguments[1].Value.Should().Be("ID");
+    }
+
     [TestMethod]
     public void EnumWithoutAttributes_Should_HaveEmptyAttributeCollection()
     {

--- a/tests/DendroDocs.Tool.Tests/SerializationTests.cs
+++ b/tests/DendroDocs.Tool.Tests/SerializationTests.cs
@@ -118,7 +118,7 @@ namespace DendroDocs.Tool.Tests
             var result = JsonConvert.SerializeObject(types, JsonDefaults.SerializerSettings());
 
             // Assert
-            result.Should().Match(@"[{""FullName"":""Test"",""Attributes"":[{""Type"":""System.ObsoleteAttribute"",""Name"":""System.Obsolete"",""Arguments"":[{""Name"":""Reason"",""Type"":""string"",""Value"":""Reason""}]}]}]");
+            result.Should().Match(@"[{""FullName"":""Test"",""Attributes"":[{""Type"":""System.ObsoleteAttribute"",""Name"":""System.Obsolete"",""Arguments"":[{""Name"":""message"",""Type"":""string"",""Value"":""Reason""}]}]}]");
         }
     }
 }


### PR DESCRIPTION
<!-- Description -->

As an `attribute` uses its constructor with positional arguments, we can look at the constructor parameter names to use.

Improve attribute extraction and handling.

- `SourceAnalyzer.cs`: Simplified `ExtractAttributes` by delegating tasks to new methods `CreateAttributeDescription`, `AddAttributeArguments`, and `CreateArgumentDescription`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!-- 
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
-->

- Added new tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

