### PR TITLE
Set record property modifiers correctly

### DIFF
--- a/src/DendroDocs.Tool/Analyzers/SourceAnalyzer.cs
+++ b/src/DendroDocs.Tool/Analyzers/SourceAnalyzer.cs
@@ -376,6 +376,15 @@ public class SourceAnalyzer(SemanticModel semanticModel, List<TypeDescription> t
     {
         var modifiers = property.IsReadOnly ? Modifier.Readonly : 0;
 
+        modifiers |= property.DeclaredAccessibility switch
+        {
+            Accessibility.Public => Modifier.Public,
+            Accessibility.Protected => Modifier.Protected,
+            Accessibility.Internal => Modifier.Internal,
+            Accessibility.Private => Modifier.Private,
+            _ => 0
+        };
+
         var propertyDescription = new PropertyDescription(property.Type.ToDisplayString(), property.Name)
         {
             Modifiers = modifiers

--- a/tests/DendroDocs.Tool.Tests/RecordDeclarationTests.cs
+++ b/tests/DendroDocs.Tool.Tests/RecordDeclarationTests.cs
@@ -105,4 +105,44 @@ public class RecordDeclarationTests
         // Assert
         types[1].Modifiers.Should().HaveFlag(modifier);
     }
+
+    [TestMethod]
+    public void RecordPropertiesShouldHaveCorrectAccessModifiersBasedOnDefault()
+    {
+        // Assign
+        var source =
+            $$"""
+            public record Person(string FirstName, string LastName)
+            {
+            }
+            """;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
+
+        // Assert
+        types[0].Properties[0].Modifiers.Should().HaveFlag(Modifier.Protected);
+        types[0].Properties[1].Modifiers.Should().HaveFlag(Modifier.Public);
+        types[0].Properties[2].Modifiers.Should().HaveFlag(Modifier.Public);
+    }
+
+    [TestMethod]
+    public void SealedRecordPropertiesShouldHaveCorrectAccessModifiers()
+    {
+        // Assign
+        var source =
+            $$"""
+            public sealed record Person(string FirstName, string LastName)
+            {
+            }
+            """;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
+
+        // Assert
+        types[0].Properties[0].Modifiers.Should().HaveFlag(Modifier.Private);
+        types[0].Properties[1].Modifiers.Should().HaveFlag(Modifier.Public);
+        types[0].Properties[2].Modifiers.Should().HaveFlag(Modifier.Public);
+    }
 }


### PR DESCRIPTION
<!-- Description -->

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Record properties (e.g. positional parameters, EqualityContract) were not detecting the correct accessibility modifiers.

Refactored `SourceAnalyzer` to improve record declaration processing and added tests for property access modifiers.
- `SourceAnalyzer.cs`: Introduced `ProcessRecordSymbolInformation`, `ProcessConstructors`, and `ProcessProperties` methods.
- `RecordDeclarationTests.cs`: Added tests for property access modifiers in records.


## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- 
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
-->

Added tests.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

