### PR TITLE
Add schema validation to the generated output

### DIFF
--- a/src/DendroDocs.Tool/DendroDocs.Tool.csproj
+++ b/src/DendroDocs.Tool/DendroDocs.Tool.csproj
@@ -28,6 +28,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="schema.json" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<Using Include="CommandLine" />
 		<Using Include="DendroDocs.Extensions" />
@@ -42,6 +46,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="DendroDocs.Shared" Version="0.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/src/DendroDocs.Tool/JsonValidator.cs
+++ b/src/DendroDocs.Tool/JsonValidator.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using System.Reflection;
+
+namespace DendroDocs.Tool;
+
+public class JsonValidator
+{
+    private const string SchemaResource = "DendroDocs.Tool.schema.json";
+
+    public static bool ValidateJson(ref string jsonContent, out IList<string> validationErrors)
+    {
+        validationErrors = [];
+
+        try
+        {
+            var schema = JSchema.Parse(LoadSchema());
+            var json = JToken.Parse(jsonContent);
+
+            if (json.IsValid(schema, out validationErrors))
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            validationErrors.Add($"Exception during validation: {ex.Message}");
+        }
+
+        return false;
+    }
+
+    private static string LoadSchema()
+    {
+        using Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(SchemaResource)!;
+        using StreamReader reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/DendroDocs.Tool/schema.json
+++ b/src/DendroDocs.Tool/schema.json
@@ -1,0 +1,555 @@
+﻿{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://dendrodocs.dev/schemas/v0/intermediary-json-schema.json",
+    "title": "Intermediary JSON for DendroDocs",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "FullName": {
+                "type": "string"
+            },
+            "Type": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "Modifiers": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "BaseTypes": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "Fields": {
+                "$ref": "#/$defs/fields"
+            },
+            "Constructors": {
+                "$ref": "#/$defs/constructors"
+            },
+            "Methods": {
+                "$ref": "#/$defs/methods"
+            },
+            "Properties": {
+                "$ref": "#/$defs/$properties"
+            },
+            "Attributes": {
+                "$ref": "#/$defs/attributes"
+            },
+            "EnumMembers": {
+                "$ref": "#/$defs/enumMembers"
+            },
+            "Events": {
+                "$ref": "#/$defs/events"
+            },
+            "DocumentationComments": {
+                "$ref": "#/$defs/documentationComments"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "FullName"
+        ]
+    },
+    "$defs": {
+        "statements": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/$defs/forEach"
+                    },
+                    {
+                        "$ref": "#/$defs/if"
+                    },
+                    {
+                        "$ref": "#/$defs/switch"
+                    },
+                    {
+                        "$ref": "#/$defs/invocation"
+                    },
+                    {
+                        "$ref": "#/$defs/assignment"
+                    },
+                    {
+                        "$ref": "#/$defs/return"
+                    }
+                ]
+            }
+        },
+        "forEach": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.ForEach, DendroDocs.Shared"
+                },
+                "Expression": {
+                    "type": "string"
+                },
+                "Statements": {
+                    "$ref": "#/$defs/statements"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "if": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.If, DendroDocs.Shared"
+                },
+                "Sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "Condition": {
+                                "type": "string"
+                            },
+                            "Statements": {
+                                "$ref": "#/$defs/statements"
+                            }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Sections"
+            ]
+        },
+        "switch": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.Switch, DendroDocs.Shared"
+                },
+                "Expression": {
+                    "type": "string"
+                },
+                "Sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "Labels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "Statements": {
+                                "$ref": "#/$defs/statements"
+                            }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "invocation": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.InvocationDescription, DendroDocs.Shared"
+                },
+                "ContainingType": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Arguments": {
+                    "$ref": "#/$defs/arguments"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Name"
+            ]
+        },
+        "assignment": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.AssignmentDescription, DendroDocs.Shared"
+                },
+                "Left": {
+                    "type": "string"
+                },
+                "Operator": {
+                    "type": "string"
+                },
+                "Right": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Left",
+                "Right",
+                "Operator"
+            ]
+        },
+        "return": {
+            "type": "object",
+            "properties": {
+                "$type": {
+                    "const": "DendroDocs.ReturnDescription, DendroDocs.Shared"
+                },
+                "Expression": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "fields": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Initializer": {
+                        "type": "string"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name",
+                    "Type"
+                ]
+            }
+        },
+        "documentationComments": {
+            "type": "object",
+            "properties": {
+                "Example": {
+                    "type": "string"
+                },
+                "Exceptions": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Params": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Permissions": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Remarks": {
+                    "type": "string"
+                },
+                "Returns": {
+                    "type": "string"
+                },
+                "SeeAlsos": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Summary": {
+                    "type": "string"
+                },
+                "TypeParams": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "attributes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Arguments": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "Name": {
+                                    "type": "string"
+                                },
+                                "Type": {
+                                    "type": "string"
+                                },
+                                "Value": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "Name",
+                                "Type",
+                                "Value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name"
+                ]
+            }
+        },
+        "arguments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Text": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Text"
+                ]
+            }
+        },
+        "constructors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Parameters": {
+                        "$ref": "#/$defs/parameters"
+                    },
+                    "Statements": {
+                        "$ref": "#/$defs/statements"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name"
+                ]
+            }
+        },
+        "parameters": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "HasDefaultValue": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Type",
+                    "Name"
+                ]
+            }
+        },
+        "methods": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "ReturnType": {
+                        "type": "string"
+                    },
+                    "Parameters": {
+                        "$ref": "#/$defs/parameters"
+                    },
+                    "Statements": {
+                        "$ref": "#/$defs/statements"
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name"
+                ]
+            }
+        },
+        "$properties": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "Initializer": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name",
+                    "Type"
+                ]
+            }
+        },
+        "enumMembers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Value": {
+                        "type": "string"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "Arguments": {
+                        "$ref": "#/$defs/arguments"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name"
+                ]
+            }
+        },
+        "events": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Type": {
+                        "type": "string"
+                    },
+                    "Modifiers": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "DocumentationComments": {
+                        "$ref": "#/$defs/documentationComments"
+                    },
+                    "Attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "Initializer": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "Name",
+                    "Type"
+                ]
+            }
+        }
+    }
+}

--- a/tests/DendroDocs.Tool.Tests/JsonValidationTests.cs
+++ b/tests/DendroDocs.Tool.Tests/JsonValidationTests.cs
@@ -1,0 +1,104 @@
+namespace DendroDocs.Tool.Tests;
+
+[TestClass]
+public class JsonValidationTests
+{
+    [TestMethod]
+    public void ValidJsonShouldValidateSuccessfully()
+    {
+        // Arrange
+        string content =
+            """
+            [
+                { "FullName": "ValidJson" }
+            ]
+            """;
+
+        // Act
+        var isValid = JsonValidator.ValidateJson(ref content, out IList<string> validationErrors);
+
+        // Assert
+        isValid.Should().BeTrue();
+        validationErrors.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void MissingFullNameShouldFailValidation()
+    {
+        // Arrange
+        string content =
+            """
+            [
+                { "BaseTypes": ["ValidJson"] }
+            ]
+            """;
+
+        // Act
+        var isValid = JsonValidator.ValidateJson(ref content, out IList<string> validationErrors);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationErrors.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void MismatchedTypeShouldFailValidation()
+    {
+        // Arrange
+        string content =
+            """
+            [
+                { "FullName": 123 }
+            ]
+            """;
+
+        // Act
+        var isValid = JsonValidator.ValidateJson(ref content, out IList<string> validationErrors);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationErrors.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void MalformedJsonShouldFailValidation()
+    {
+        // Arrange
+        string content =
+            """
+            [
+                { "FullName": "ValidJson" }
+            """;
+
+        // Act
+        var isValid = JsonValidator.ValidateJson(ref content, out IList<string> validationErrors);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationErrors.Should().ContainSingle()
+            .Which.Should().StartWith("Exception during validation");
+    }
+
+    [TestMethod]
+    public void UnexpectedElementsShouldFailValidation()
+    {
+        // Arrange
+        string content = 
+            """
+            [
+                {
+                    "FullName": "ValidJson",
+                    "Unexpected": true
+                }
+            ]
+            """;
+
+        // Act
+        var isValid = JsonValidator.ValidateJson(ref content, out IList<string> validationErrors);
+
+        // Assert
+        isValid.Should().BeFalse();
+        validationErrors.Should().ContainSingle()
+            .Which.Should().Contain("Unexpected");
+    }
+}


### PR DESCRIPTION
<!-- Description -->

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add JSON schema validation for output JSON.
Added a non-`0` return code when validation fails.

Originally suggested by @Ali-chakaroun in https://github.com/eNeRGy164/LivingDocumentation/pull/69.

Introduced JSON schema validation using `Newtonsoft.Json.Schema` and updated the application to handle validation results.
- `DendroDocs.Tool.csproj`: Added `schema.json` as an embedded resource and referenced `Newtonsoft.Json.Schema`.
- `JsonValidator.cs`: Introduced `JsonValidator` class for JSON validation.
- `Program.cs`: Updated `Main` and `RunApplicationAsync` methods to handle validation results.
- `JsonValidationTests.cs`: Added tests for JSON validation against the schema.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!-- 
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
-->

Added new tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

